### PR TITLE
Do not re initialize the structure on break

### DIFF
--- a/rollbar/invites.go
+++ b/rollbar/invites.go
@@ -19,8 +19,9 @@ type ListInvitesResponse struct {
 	}
 }
 
+var data ListInvitesResponse
+
 func (c *Client) ListInvites(teamID int) (*ListInvitesResponse, error) {
-	var data ListInvitesResponse
 
 	// Invitation call has pagination.
 	// There's a feature request to expire the invitations after some time.


### PR DESCRIPTION
- I've noticed this bug while doing the terraform provider, it got an empty struct while the client was doing the break.