### PR TITLE
Fix_the_logic_in_the_listinvites

### DIFF
--- a/rollbar/invites.go
+++ b/rollbar/invites.go
@@ -6,27 +6,31 @@ import (
 	"net/http"
 )
 
-type ListInvitesResponse struct {
-	Error  int `json:"err"`
-	Result []struct {
-		ID           int    `json:"id"`
-		FromUserID   int    `json:"from_user_id"`
-		TeamID       int    `json:"team_id"`
-		ToEmail      string `json:"to_email"`
-		Status       string `json:"status"`
-		DateCreated  int    `json:"date_created"`
-		DateRedeemed int    `json:"date_redeemed"`
-	}
+type ListInvitesResultResponse struct {
+	ID           int    `json:"id"`
+	FromUserID   int    `json:"from_user_id"`
+	TeamID       int    `json:"team_id"`
+	ToEmail      string `json:"to_email"`
+	Status       string `json:"status"`
+	DateCreated  int    `json:"date_created"`
+	DateRedeemed int    `json:"date_redeemed"`
 }
 
-func (c *Client) ListInvites(teamID int) (*ListInvitesResponse, error) {
-	var data ListInvitesResponse
+type ListInvitesResponse struct {
+	Error  int `json:"err"`
+	Result []ListInvitesResultResponse
+}
 
+func (c *Client) ListInvites(teamID int) ([]ListInvitesResultResponse, error) {
+	var invites []ListInvitesResultResponse
 	// Invitation call has pagination.
 	// There's a feature request to expire the invitations after some time.
 	// Looping until we get an empty invitations list [].
 	// Page=0 and page=1 return the same result.
 	for i := 1; ; i++ {
+		var data ListInvitesResponse
+		var dataResponses []ListInvitesResultResponse
+
 		pageNum := i
 		url := fmt.Sprintf("%steam/%d/invites?access_token=%s&page=%d", c.ApiBaseUrl, teamID, c.ApiKey, pageNum)
 		req, err := http.NewRequest("GET", url, nil)
@@ -42,6 +46,8 @@ func (c *Client) ListInvites(teamID int) (*ListInvitesResponse, error) {
 		}
 
 		err = json.Unmarshal(bytes, &data)
+		dataResponses = data.Result
+		invites = append(invites, dataResponses...)
 
 		if err != nil {
 			return nil, err
@@ -51,5 +57,5 @@ func (c *Client) ListInvites(teamID int) (*ListInvitesResponse, error) {
 			break
 		}
 	}
-	return &data, nil
+	return invites, nil
 }

--- a/rollbar/invites.go
+++ b/rollbar/invites.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 )
 
-type ListInvitesResultResponse struct {
+type Invites struct {
 	ID           int    `json:"id"`
 	FromUserID   int    `json:"from_user_id"`
 	TeamID       int    `json:"team_id"`
@@ -18,18 +18,18 @@ type ListInvitesResultResponse struct {
 
 type ListInvitesResponse struct {
 	Error  int `json:"err"`
-	Result []ListInvitesResultResponse
+	Result []Invites
 }
 
-func (c *Client) ListInvites(teamID int) ([]ListInvitesResultResponse, error) {
-	var invites []ListInvitesResultResponse
+func (c *Client) ListInvites(teamID int) ([]Invites, error) {
+	var invites []Invites
 	// Invitation call has pagination.
 	// There's a feature request to expire the invitations after some time.
 	// Looping until we get an empty invitations list [].
 	// Page=0 and page=1 return the same result.
 	for i := 1; ; i++ {
 		var data ListInvitesResponse
-		var dataResponses []ListInvitesResultResponse
+		var dataResponses []Invites
 
 		pageNum := i
 		url := fmt.Sprintf("%steam/%d/invites?access_token=%s&page=%d", c.ApiBaseUrl, teamID, c.ApiKey, pageNum)

--- a/rollbar/invites.go
+++ b/rollbar/invites.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 )
 
-type Invites struct {
+type Invite struct {
 	ID           int    `json:"id"`
 	FromUserID   int    `json:"from_user_id"`
 	TeamID       int    `json:"team_id"`
@@ -18,18 +18,18 @@ type Invites struct {
 
 type ListInvitesResponse struct {
 	Error  int `json:"err"`
-	Result []Invites
+	Result []Invite
 }
 
-func (c *Client) ListInvites(teamID int) ([]Invites, error) {
-	var invites []Invites
+func (c *Client) ListInvites(teamID int) ([]Invite, error) {
+	var invites []Invite
 	// Invitation call has pagination.
 	// There's a feature request to expire the invitations after some time.
 	// Looping until we get an empty invitations list [].
 	// Page=0 and page=1 return the same result.
 	for i := 1; ; i++ {
 		var data ListInvitesResponse
-		var dataResponses []Invites
+		var dataResponses []Invite
 
 		pageNum := i
 		url := fmt.Sprintf("%steam/%d/invites?access_token=%s&page=%d", c.ApiBaseUrl, teamID, c.ApiKey, pageNum)


### PR DESCRIPTION
The terraform provider was getting an empty slice which was breaking the provider itself. Because of the pagination I made some changes to client
so that it passes all the data it gets from the rollbar api.