### PR TITLE
Use a dereferenced client

### DIFF
--- a/rollbar/invites.go
+++ b/rollbar/invites.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 )
 
+// Invite : A data structure for the nested invites from the ListInvitesResponse.
 type Invite struct {
 	ID           int    `json:"id"`
 	FromUserID   int    `json:"from_user_id"`
@@ -16,11 +17,13 @@ type Invite struct {
 	DateRedeemed int    `json:"date_redeemed"`
 }
 
+// ListInvitesResponse : A data structure for the ListInvites response.
 type ListInvitesResponse struct {
 	Error  int `json:"err"`
 	Result []Invite
 }
 
+// ListInvites : A function to list all the invites.
 func (c *Client) ListInvites(teamID int) ([]Invite, error) {
 	var invites []Invite
 	// Invitation call has pagination.
@@ -32,7 +35,7 @@ func (c *Client) ListInvites(teamID int) ([]Invite, error) {
 		var dataResponses []Invite
 
 		pageNum := i
-		url := fmt.Sprintf("%steam/%d/invites?access_token=%s&page=%d", c.ApiBaseUrl, teamID, c.ApiKey, pageNum)
+		url := fmt.Sprintf("%steam/%d/invites?access_token=%s&page=%d", c.APIBaseURL, teamID, c.APIKEY, pageNum)
 		req, err := http.NewRequest("GET", url, nil)
 
 		if err != nil {

--- a/rollbar/invites.go
+++ b/rollbar/invites.go
@@ -35,7 +35,7 @@ func (c *Client) ListInvites(teamID int) ([]Invite, error) {
 		var dataResponses []Invite
 
 		pageNum := i
-		url := fmt.Sprintf("%steam/%d/invites?access_token=%s&page=%d", c.APIBaseURL, teamID, c.APIKEY, pageNum)
+		url := fmt.Sprintf("%steam/%d/invites?access_token=%s&page=%d", c.APIBaseURL, teamID, c.APIKey, pageNum)
 		req, err := http.NewRequest("GET", url, nil)
 
 		if err != nil {

--- a/rollbar/invites_test.go
+++ b/rollbar/invites_test.go
@@ -18,9 +18,9 @@ func TestListInvites(t *testing.T) {
 	}
 
 	teamID := vars.TeamID
-	handUrl := fmt.Sprintf("/team/%d/invites/", teamID)
+	handURL := fmt.Sprintf("/team/%d/invites/", teamID)
 
-	mux.HandleFunc(handUrl, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(handURL, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		page := r.URL.Query().Get("pages")

--- a/rollbar/rollbar.go
+++ b/rollbar/rollbar.go
@@ -15,7 +15,7 @@ type Option func(*Client) error
 
 // Client : A data structure for the rollbar client.
 type Client struct {
-	APIKEY     string
+	APIKey     string
 	APIBaseURL string
 }
 
@@ -44,7 +44,7 @@ func (c *Client) parseOptions(opts ...Option) error {
 // NewClient : A function for initiating the client.
 func NewClient(apiKey string, opts ...Option) (*Client, error) {
 	client := Client{
-		APIKEY:     apiKey,
+		APIKey:     apiKey,
 		APIBaseURL: apiBaseURL,
 	}
 	if err := client.parseOptions(opts...); err != nil {

--- a/rollbar/rollbar.go
+++ b/rollbar/rollbar.go
@@ -6,20 +6,23 @@ import (
 	"net/http"
 )
 
-const apiBaseUrl string = "https://api.rollbar.com/api/1/"
+const apiBaseURL string = "https://api.rollbar.com/api/1/"
 
 var apiKey string
 
+// Option : A function to add the base url and other parameters to the client.
 type Option func(*Client) error
 
+// Client : A data structure for the rollbar client.
 type Client struct {
-	ApiKey     string
-	ApiBaseUrl string
+	APIKEY     string
+	APIBaseURL string
 }
 
+// BaseURL : A function for construction the rul to the api.
 func BaseURL(baseURL string) Option {
 	return func(c *Client) error {
-		c.ApiBaseUrl = baseURL
+		c.APIBaseURL = baseURL
 		return nil
 	}
 }
@@ -38,15 +41,16 @@ func (c *Client) parseOptions(opts ...Option) error {
 	return nil
 }
 
+// NewClient : A function for initiating the client.
 func NewClient(apiKey string, opts ...Option) (*Client, error) {
-	client := &Client{
-		ApiKey:     apiKey,
-		ApiBaseUrl: apiBaseUrl,
+	client := Client{
+		APIKEY:     apiKey,
+		APIBaseURL: apiBaseURL,
 	}
 	if err := client.parseOptions(opts...); err != nil {
 		return nil, err
 	}
-	return client, nil
+	return &client, nil
 }
 
 func (c *Client) makeRequest(req *http.Request) ([]byte, error) {

--- a/rollbar/test_setup.go
+++ b/rollbar/test_setup.go
@@ -18,6 +18,7 @@ var (
 	client *Client
 )
 
+// VarsUsers : A data structure for the mock response.
 type VarsUsers struct {
 	TeamID    int    `json:"TeamID"`
 	UserID    int    `json:"UserID"`
@@ -25,11 +26,11 @@ type VarsUsers struct {
 }
 
 func setup() func() {
-	const mockApiKey = "mockApiKey"
+	const mockAPIKey = "mockApiKey"
 
 	mux = http.NewServeMux()
 	server = httptest.NewServer(mux)
-	client, _ = NewClient(mockApiKey, BaseURL(server.URL+"/"))
+	client, _ = NewClient(mockAPIKey, BaseURL(server.URL+"/"))
 
 	return func() {
 		server.Close()

--- a/rollbar/users.go
+++ b/rollbar/users.go
@@ -43,7 +43,7 @@ func (c *Client) InviteUser(teamID int, email string) (*InviteResponse, error) {
 	}
 
 	url := fmt.Sprintf("%steam/%d/invites", c.APIBaseURL, teamID)
-	reqData := requestData{c.APIKEY, email}
+	reqData := requestData{c.APIKey, email}
 	b, err := json.Marshal(reqData)
 
 	if err != nil {
@@ -74,7 +74,7 @@ func (c *Client) InviteUser(teamID int, email string) (*InviteResponse, error) {
 func (c *Client) ListUsers() (*ListUsersResponse, error) {
 	var data ListUsersResponse
 
-	url := fmt.Sprintf("%susers?access_token=%s", c.APIBaseURL, c.APIKEY)
+	url := fmt.Sprintf("%susers?access_token=%s", c.APIBaseURL, c.APIKey)
 	req, err := http.NewRequest("GET", url, nil)
 
 	if err != nil {
@@ -134,7 +134,7 @@ func (c *Client) RemoveUserTeam(email string, teamID int) error {
 		return err
 	}
 
-	url := fmt.Sprintf("%steam/%d/user/%d?access_token=%s", c.APIBaseURL, teamID, userID, c.APIKEY)
+	url := fmt.Sprintf("%steam/%d/user/%d?access_token=%s", c.APIBaseURL, teamID, userID, c.APIKey)
 	req, err := http.NewRequest("DELETE", url, nil)
 
 	if err != nil {

--- a/rollbar/users.go
+++ b/rollbar/users.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 )
 
+// ListUsersResponse : A data structure for the list users response.
 type ListUsersResponse struct {
 	Error  int `json:"err"`
 	Result struct {
@@ -18,6 +19,7 @@ type ListUsersResponse struct {
 	}
 }
 
+// InviteResponse : A data structure for the list invites response.
 type InviteResponse struct {
 	Error  int `json:"err"`
 	Result struct {
@@ -31,6 +33,7 @@ type InviteResponse struct {
 	}
 }
 
+// InviteUser :  A function for sending an invitation to a user.
 func (c *Client) InviteUser(teamID int, email string) (*InviteResponse, error) {
 	var data InviteResponse
 
@@ -39,8 +42,8 @@ func (c *Client) InviteUser(teamID int, email string) (*InviteResponse, error) {
 		Email       string `json:"email"`
 	}
 
-	url := fmt.Sprintf("%steam/%d/invites", c.ApiBaseUrl, teamID)
-	reqData := requestData{c.ApiKey, email}
+	url := fmt.Sprintf("%steam/%d/invites", c.APIBaseURL, teamID)
+	reqData := requestData{c.APIKEY, email}
 	b, err := json.Marshal(reqData)
 
 	if err != nil {
@@ -67,10 +70,11 @@ func (c *Client) InviteUser(teamID int, email string) (*InviteResponse, error) {
 	return &data, nil
 }
 
+// ListUsers : A function for listing the users.
 func (c *Client) ListUsers() (*ListUsersResponse, error) {
 	var data ListUsersResponse
 
-	url := fmt.Sprintf("%susers?access_token=%s", c.ApiBaseUrl, c.ApiKey)
+	url := fmt.Sprintf("%susers?access_token=%s", c.APIBaseURL, c.APIKEY)
 	req, err := http.NewRequest("GET", url, nil)
 
 	if err != nil {
@@ -112,6 +116,7 @@ func (c *Client) getID(email string) (int, error) {
 	return userID, nil
 }
 
+// GetUser : A function for getting 1 user.
 func (c *Client) GetUser(email string) (int, error) {
 	userID, err := c.getID(email)
 	if err != nil {
@@ -121,6 +126,7 @@ func (c *Client) GetUser(email string) (int, error) {
 
 }
 
+// RemoveUserTeam : A function for removing a user from a team.
 func (c *Client) RemoveUserTeam(email string, teamID int) error {
 	userID, err := c.GetUser(email)
 
@@ -128,7 +134,7 @@ func (c *Client) RemoveUserTeam(email string, teamID int) error {
 		return err
 	}
 
-	url := fmt.Sprintf("%steam/%d/user/%d?access_token=%s", c.ApiBaseUrl, teamID, userID, c.ApiKey)
+	url := fmt.Sprintf("%steam/%d/user/%d?access_token=%s", c.APIBaseURL, teamID, userID, c.APIKEY)
 	req, err := http.NewRequest("DELETE", url, nil)
 
 	if err != nil {

--- a/rollbar/users_test.go
+++ b/rollbar/users_test.go
@@ -20,16 +20,16 @@ func TestRemoveUserTeam(t *testing.T) {
 	userID := vars.UserID
 	userEmail := vars.UserEmail
 
-	handUrl := fmt.Sprintf("/team/%d/user/%d", teamID, userID)
-	handUrlGet := "/users/"
+	handURL := fmt.Sprintf("/team/%d/user/%d", teamID, userID)
+	handURLGet := "/users/"
 
-	mux.HandleFunc(handUrl, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(handURL, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, fixture("users/remove_user.json"))
 	})
 
-	mux.HandleFunc(handUrlGet, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(handURLGet, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, fixture("users/users.json"))
@@ -53,9 +53,9 @@ func TestInviteUser(t *testing.T) {
 
 	teamID := vars.TeamID
 	userEmail := vars.UserEmail
-	handUrl := fmt.Sprintf("/team/%d/invites", teamID)
+	handURL := fmt.Sprintf("/team/%d/invites", teamID)
 
-	mux.HandleFunc(handUrl, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(handURL, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, fixture("teams/invite_user.json"))
@@ -71,9 +71,9 @@ func TestListUsers(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
-	handUrl := "/users"
+	handURL := "/users"
 
-	mux.HandleFunc(handUrl, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(handURL, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, fixture("users/users.json"))
@@ -98,9 +98,9 @@ func TestGetId(t *testing.T) {
 
 	userID := vars.UserID
 	userEmail := vars.UserEmail
-	handUrl := "/users"
+	handURL := "/users"
 
-	mux.HandleFunc(handUrl, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(handURL, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, fixture("users/users.json"))


### PR DESCRIPTION
- Change the return of the NewClient function so that it doesn't need dereferencing.
  - https://github.com/babbel/rollbar-go/compare/use_a_dereferenced_client?expand=1#diff-4e698217979ac221536da72a8276e9aeR46
- Improve the code by adhering to golang standards.